### PR TITLE
Malloc lab best fit and pre-allocate free block with small malloc requests

### DIFF
--- a/malloclab-handout/eval.md
+++ b/malloclab-handout/eval.md
@@ -14,7 +14,7 @@ Perf index = 33 (util) + 40 (thru) = 73/100
 Running: ./mdriver -f traces/binary2-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 31 (util) + 10 (thru) = 41/100
+Perf index = 31 (util) + 11 (thru) = 42/100
 ----------------------------------------
 Running: ./mdriver -f traces/cccp-bal.rep
 Team Name:Team
@@ -39,25 +39,25 @@ Perf index = 60 (util) + 40 (thru) = 100/100
 Running: ./mdriver -f traces/random-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 56 (util) + 40 (thru) = 96/100
+Perf index = 57 (util) + 40 (thru) = 97/100
 ----------------------------------------
 Running: ./mdriver -f traces/random2-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 55 (util) + 40 (thru) = 95/100
+Perf index = 57 (util) + 40 (thru) = 97/100
 ----------------------------------------
 Running: ./mdriver -f traces/realloc-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 31 (util) + 40 (thru) = 71/100
+Perf index = 20 (util) + 40 (thru) = 60/100
 ----------------------------------------
 Running: ./mdriver -f traces/realloc2-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 27 (util) + 40 (thru) = 67/100
+Perf index = 17 (util) + 40 (thru) = 57/100
 ----------------------------------------
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
 Using default tracefiles in traces/
-Perf index = 48 (util) + 40 (thru) = 88/100
+Perf index = 47 (util) + 40 (thru) = 87/100
 ```

--- a/malloclab-handout/eval.md
+++ b/malloclab-handout/eval.md
@@ -9,12 +9,12 @@ Perf index = 60 (util) + 40 (thru) = 100/100
 Running: ./mdriver -f traces/binary-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 33 (util) + 40 (thru) = 73/100
+Perf index = 53 (util) + 40 (thru) = 93/100
 ----------------------------------------
 Running: ./mdriver -f traces/binary2-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 31 (util) + 11 (thru) = 42/100
+Perf index = 49 (util) + 31 (thru) = 79/100
 ----------------------------------------
 Running: ./mdriver -f traces/cccp-bal.rep
 Team Name:Team
@@ -54,10 +54,10 @@ Perf index = 20 (util) + 40 (thru) = 60/100
 Running: ./mdriver -f traces/realloc2-bal.rep
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
-Perf index = 17 (util) + 40 (thru) = 57/100
+Perf index = 45 (util) + 40 (thru) = 85/100
 ----------------------------------------
 Team Name:Team
 Member 1 :Yehua Fei:hello@csapp.it
 Using default tracefiles in traces/
-Perf index = 47 (util) + 40 (thru) = 87/100
+Perf index = 53 (util) + 40 (thru) = 93/100
 ```

--- a/malloclab-handout/mm.c
+++ b/malloclab-handout/mm.c
@@ -1,7 +1,7 @@
 /*
  * @Author       : FeiYehua
  * @Date         : 2015-04-02 02:12:26
- * @LastEditTime : 2025-08-15 01:35:12
+ * @LastEditTime : 2025-08-18 00:55:07
  * @LastEditors  : FeiYehua
  * @Description  :
  * @FilePath     : mm.c
@@ -130,10 +130,25 @@ int mm_init(void)
  * mm_malloc - Allocate a block by incrementing the brk pointer.
  *     Always allocate a block whose size is a multiple of the alignment.
  */
+
+#define SMALL_SIZE 64
 void *mm_malloc(size_t size)
 {
     void *free_bp = find_fit(size);
-    return (free_bp != NULL) ? free_bp : extend_heap(size);
+    if (free_bp == NULL && size <= SMALL_SIZE)
+    {
+        size_t newsize = MAX(ALIGN(size + sizeof(size_t)), 16);
+        free_bp = extend_heap(newsize * 4 - sizeof(size_t));
+        void *free_bp_header_ptr = HDRP(free_bp);
+        unsigned int free_bp_header_content = GET(free_bp_header_ptr);
+        split_block(free_bp, newsize, free_bp_header_content);
+        return free_bp;
+    }
+    else if (free_bp == NULL)
+    {
+        return extend_heap(size);
+    }
+    return free_bp;
 }
 
 /*
@@ -148,8 +163,8 @@ void add_footer(void *bp)
 }
 
 /*
- * mm_free - Freeing a block does nothing.
- argument ptr is a pointer to the block payload.
+ * mm_free - Freeing a block.
+ * argument ptr is a pointer to the block payload.
  */
 void mm_free(void *ptr)
 {
@@ -344,12 +359,16 @@ static void *find_fit(size_t asize)
 }
 
 /*
- * split_block - Split the given (free) block into half, with the first half having size size.
+ * split_block - Split the given (free or allocated) block into half, with the first half having size size.
+ * If the given block size is bigger than size, you must make sure in the latter half have nothing important!
  * The first block is always allocated.
  */
 static void split_block(void *bp, size_t size, unsigned int block_header_content)
 {
-    delete(bp);
+    if (!GET_ALLOC(HDRP(bp)))
+    {
+        delete(bp);
+    }
     size_t oldsize = block_header_content & (~0x7);
     unsigned int mask = block_header_content & 0x7;
     PUT(HDRP(bp), size | mask | ALLOC);


### PR DESCRIPTION
Implement best-fit in choosing free blocks,
When handling a small malloc request (less than 64 bytes), allocate 4 times of the requested space to make small blocks contiguous.